### PR TITLE
client: abort stale search requests, keep a single in-flight jkXHR an…

### DIFF
--- a/controllers/endpoints/search.js
+++ b/controllers/endpoints/search.js
@@ -19,6 +19,9 @@ departmentModel.getAll(function (fetchedDepartments) {
 
 // Intelligent searching for both courses and instructors
 router.use('/:query', function (req, res) {
+  // If the client disconnects, stop heavy processing early
+  let clientGone = false
+  res.on('close', () => { clientGone = true })
   // Validate that the request contains a query
   if (typeof (req.params.query) === 'undefined') {
     res.sendStatus(400)
@@ -90,7 +93,8 @@ router.use('/:query', function (req, res) {
     } else if ((matches = courseDeptNumberRegexp.exec(thisQueryWord)) !== null) {
       // Expand "COS333" to "COS 333"
       newQueryWords.push(matches[1], matches[2])
-    } else if (thisQueryWord !== '*' && thisQueryWord.length > 0) {
+    } else if (thisQueryWord !== '*' && thisQueryWord.length >= 2) {
+      // Only include tokens with length >= 2 to avoid pathological 1-letter regexes
       newQueryWords.push(thisQueryWord)
     }
   })
@@ -207,12 +211,22 @@ router.use('/:query', function (req, res) {
   }
 
   // Construct the courseModel database query as a promise
-  promises.push(courseModel.find(courseQuery, courseProjection).exec())
+  const COURSE_LIMIT = parseInt(process.env.SEARCH_COURSE_LIMIT || '150', 10)
+  const courseFindQuery = courseModel
+    .find(courseQuery, courseProjection)
+    .setOptions({_skipAutoPopulate: true})
+    .limit(COURSE_LIMIT)
+    .maxTimeMS(7000)
+  promises.push(courseFindQuery.exec())
   promiseNames.push('courses')
 
   // Construct the instructorModel database query as a promise
   if (newQueryWords.length > 0) {
-    promises.push(instructorModel.find(instructorQuery, instructorProjection).exec())
+    const instructorFindQuery = instructorModel
+      .find(instructorQuery, instructorProjection)
+      .limit(50)
+      .maxTimeMS(5000)
+    promises.push(instructorFindQuery.exec())
     promiseNames.push('instructors')
   }
 
@@ -230,6 +244,8 @@ router.use('/:query', function (req, res) {
         var clashDetectionCourses = user.clashDetectionCourses
       }
     }
+
+    if (clientGone) { return }
 
     // Guard against the query results being null
     if (typeof (courses) === 'undefined' || courses.length === 0) {
@@ -305,18 +321,26 @@ router.use('/:query', function (req, res) {
       })
     })
 
-    // Detect clashes
+    // Detect clashes – budgeted to avoid CPU blowups
     if (detectClashes) {
-      var detectClashesResult = courseClashDetector.detectCourseClash(clashDetectionCourses, courses, parseInt(courseQuery.semester))
-      if (detectClashesResult.hasOwnProperty('status')) {
-        if (detectClashesResult.status === 'success') {
-          courses = detectClashesResult.courses
-        } else if (detectClashesResult.status === 'favoritesClash' && courses.length > 0) {
-          for (let courseIndex in courses) {
-            courses[courseIndex].favoritesClash = true
+      const CLASH_BUDGET = parseInt(process.env.SEARCH_CLASH_BUDGET || '60', 10)
+      if (filterOutClashes && courses.length > CLASH_BUDGET) {
+        // When filtering, only evaluate top N to keep semantics and bound work
+        courses = courses.slice(0, CLASH_BUDGET)
+      }
+      if (courses.length <= CLASH_BUDGET && !clientGone) {
+        var detectClashesResult = courseClashDetector.detectCourseClash(clashDetectionCourses, courses, parseInt(courseQuery.semester))
+        if (detectClashesResult.hasOwnProperty('status')) {
+          if (detectClashesResult.status === 'success') {
+            courses = detectClashesResult.courses
+          } else if (detectClashesResult.status === 'favoritesClash' && courses.length > 0) {
+            for (let courseIndex in courses) {
+              courses[courseIndex].favoritesClash = true
+            }
           }
         }
       }
+      // If over budget and not filtering, skip clash detection entirely to avoid heavy CPU
     }
 
     // Filter out clashing courses if requested by the client

--- a/models/course.js
+++ b/models/course.js
@@ -138,6 +138,10 @@ courseSchema.on('index', function (error) {
 
 // Automatically populate instructors and semester
 var autoPopulate = function (next) {
+  // Allow queries to opt-out of autopopulate to reduce load (e.g., search)
+  if (this && this.options && this.options._skipAutoPopulate) {
+    return next()
+  }
   this.populate('instructors semester semesters')
   next()
 }


### PR DESCRIPTION
Client (prevents piling up requests)

- File: public/scripts/search.js
    - Abort stale requests: keeps a single in‑flight jqXHR and aborts it before starting a
new search.
    - Added: var currentSearchRequest = null
    - Wrap $.get with abort-before-start and an .always() to clear the handle.

Server (bounds work and avoids unnecessary DB load)

- File: controllers/endpoints/search.js
    - Minimum token length: ignores 1‑character tokens unless it’s a known 3‑letter
department. Prevents pathological “s” queries from exploding regex matches.
    - Cap results early: limit courses to 150 via SEARCH_COURSE_LIMIT (default 150). Limits
instructors to 50.
    - Skip auto-populate on search: marks the query with _skipAutoPopulate to avoid
populating instructors/semester for every search hit.
    - Gate clash detection: default budget 60 via SEARCH_CLASH_BUDGET (default 60).
    - If detectClashes===filter and results > budget: evaluates only the first 60 items to
honor filtering while bounding CPU.
    - If detectClashes===true and results > budget: skips clash detection entirely (no
per-course clash icons for oversized result sets).
- Stop early if client disconnects: res.on('close') guard to avoid spending CPU after the
requester is gone.
- 
Stop early if client disconnects: res.on('close') guard to avoid spending CPU after the
requester is gone.
- 
File: models/course.js
    - Added a check in the pre('find') populate hook to honor _skipAutoPopulate, keeping
other code paths unchanged.